### PR TITLE
Replace Underscore with lodash

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [Ramda](https://github.com/ramda/ramda)
 - [wu](http://fitzgen.github.io/wu.js/)
 - [Bacon](http://github.com/baconjs/bacon.js/)
-- [Underscore](https://github.com/jashkenas/underscore)
+- [lodash](https://www.npmjs.com/package/lodash)
 
 
 ## Searching


### PR DESCRIPTION
`lodash` is a fork of Underscore that follows semver, is faster, has more features, and (from what I've gathered) follows up on bug reports better.